### PR TITLE
Allow port override for metasearch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ ${JSON.stringify(data)}`);
 
   // Set up server
   const app = express();
-  const port = 3000;
+  const port = process.env.PORT || 3000;
   app.use(compression());
   app.use(express.static("dist"));
 


### PR DESCRIPTION
Allow port that metasearch listens on to be overridden by an environment variable.

This will help to get this setup on Galaxy on a different port.

Tested locally with environment variable passed in works as well as default port of 3000 works without PORT passed in, so current configuration works as well.