### PR TITLE
Add Notion page search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The full list of supported data sources:
 - [Jenkins](https://www.jenkins.io/) job names
 - [Jira](https://www.atlassian.com/software/jira) issues
 - [Lingo](https://www.lingoapp.com/) assets
-- [Notion](https://notion.so) pages
+- [Notion](https://www.notion.so/) pages
 - [PagerDuty](https://www.pagerduty.com/) schedules and services
 - [Pingboard](https://pingboard.com/) employees
 - [Rollbar](https://rollbar.com/) projects

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The full list of supported data sources:
 - [Jenkins](https://www.jenkins.io/) job names
 - [Jira](https://www.atlassian.com/software/jira) issues
 - [Lingo](https://www.lingoapp.com/) assets
+- [Notion](https://notion.so) pages
 - [PagerDuty](https://www.pagerduty.com/) schedules and services
 - [Pingboard](https://pingboard.com/) employees
 - [Rollbar](https://rollbar.com/) projects
@@ -26,7 +27,6 @@ The full list of supported data sources:
 - [TalentLMS](https://www.talentlms.com/) courses
 - [Trello](https://trello.com/en-US) boards, cards, members and workspaces
 - [Zoom](https://zoom.us/) rooms
-- [Notion](https://notion.so) pages
 - Arbitrary websites via sitemaps
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The full list of supported data sources:
 - [TalentLMS](https://www.talentlms.com/) courses
 - [Trello](https://trello.com/en-US) boards, cards, members and workspaces
 - [Zoom](https://zoom.us/) rooms
+- [Notion](https://notion.so) pages
 - Arbitrary websites via sitemaps
 
 ## Setup

--- a/config.yaml
+++ b/config.yaml
@@ -143,6 +143,16 @@ engines:
       - https://www.lingoapp.com/1234/k/Icons-RWEr24?kit_token=Ex4mp1eEx4mp1eEx4mp1eEx4mp1eEx4mp1eEx4mp1eE
       - https://www.lingoapp.com/1234/k/Illustrations-Ex4mp1
 
+  # Notion page titles
+  notion:
+    # Create an internal integration at https://www.notion.so/my-integrations
+    # and paste the token below. Make sure to share the notion pages with this
+    # integration for them to be searchable.
+    token: secret_Ex4mp1eEx4mp1eEx4mp1eEEx4mp1eEx4mp1eEx4mp1eE
+    # ID of the space where you want to search pages, see URL of any page in
+    # workspace (notion.so/happy/).
+    workspace: happy
+
   # PagerDuty schedules and services
   pagerduty:
     # PagerDuty API token
@@ -202,14 +212,6 @@ engines:
     key: Ex4mp1eEx4mp1eEx4mp1eE
     # Zoom API secret used for JWT authentication
     secret: Ex4mp1eEx4mp1eEx4mp1eEx4mp1eEx4mp1eE
-
-  # Notion page titles
-  notion: 
-    # Create an internal integration at https://www.notion.so/my-integrations, and paste the token below.
-    # Make sure to share the notion pages with this integration for them to be searchable.
-    token: secret_Ex4mp1eEx4mp1eEx4mp1eEEx4mp1eEx4mp1eEx4mp1eE
-    # Id of the space where you want to search pages, see url of any page in workspace(notion.so/happy/).
-    workspace: happy
 
 
 ###############################################################################

--- a/config.yaml
+++ b/config.yaml
@@ -203,6 +203,14 @@ engines:
     # Zoom API secret used for JWT authentication
     secret: Ex4mp1eEx4mp1eEx4mp1eEx4mp1eEx4mp1eE
 
+  # Notion page titles
+  notion: 
+    # Create an internal integration at https://www.notion.so/my-integrations, and paste the token below.
+    # Make sure to share the notion pages with this integration for them to be searchable.
+    token: secret_Ex4mp1eEx4mp1eEx4mp1eEEx4mp1eEx4mp1eEx4mp1eE
+    # Id of the space where you want to search pages, see url of any page in workspace(notion.so/happy/).
+    workspace: happy
+
 
 ###############################################################################
 # ADVANCED CONFIG

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -35,6 +35,7 @@ const engines: Engine[] = [
   jenkins,
   jira,
   lingo,
+  notion,
   pagerduty,
   pingboard,
   rollbar,
@@ -43,6 +44,5 @@ const engines: Engine[] = [
   trello,
   website,
   zoom,
-  notion,
 ];
 export default engines;

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -11,15 +11,15 @@ import hound from "./hound";
 import jenkins from "./jenkins";
 import jira from "./jira";
 import lingo from "./lingo";
+import notion from "./notion";
 import pagerduty from "./pagerduty";
 import pingboard from "./pingboard";
 import rollbar from "./rollbar";
 import slack from "./slack";
-import trello from "./trello";
 import talentlms from "./talentlms";
+import trello from "./trello";
 import website from "./website";
 import zoom from "./zoom";
-import notion from "./notion"
 
 const engines: Engine[] = [
   aws,
@@ -43,6 +43,6 @@ const engines: Engine[] = [
   trello,
   website,
   zoom,
-  notion
+  notion,
 ];
 export default engines;

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -19,6 +19,7 @@ import trello from "./trello";
 import talentlms from "./talentlms";
 import website from "./website";
 import zoom from "./zoom";
+import notion from "./notion"
 
 const engines: Engine[] = [
   aws,
@@ -42,5 +43,6 @@ const engines: Engine[] = [
   trello,
   website,
   zoom,
+  notion
 ];
 export default engines;

--- a/src/engines/notion.ts
+++ b/src/engines/notion.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from "axios";
+
 import { getUnixTime } from "../util";
 
 let axiosClient: AxiosInstance | undefined;
@@ -37,7 +38,7 @@ const engine: Engine = {
     });
   },
   name: "Notion",
-  search: async (q) => {
+  search: async q => {
     if (!axiosClient) {
       throw Error("Engine not initialized");
     }
@@ -64,7 +65,7 @@ const engine: Engine = {
             modified: getUnixTime(result.last_edited_time),
             title: title.plain_text,
             url: `notion://notion.so/${notionWorkspace}/${formatTitle(
-              title.plain_text
+              title.plain_text,
             )}-${formatId(result.id)}`,
           };
         }

--- a/src/engines/notion.ts
+++ b/src/engines/notion.ts
@@ -1,52 +1,71 @@
-// import { Client } from "@notionhq/client";
-const { Client } = require("@notionhq/client");
-let notion: typeof Client;
+
+import axios, { AxiosInstance } from "axios";
+import { getUnixTime } from "../util";
+
+let axiosClient: AxiosInstance | undefined;
+let notionWorkspace: string;
 
 const engine: Engine = {
   id: "notion",
-  init: ({ token }: { token: string }) => {
-    notion = new Client({ auth: token });
+  init: ({ token, workspace }: { token: string; workspace: string }) => {
+    token = token;
+    notionWorkspace = workspace;
+    axiosClient = axios.create({
+      baseURL: "https://api.notion.com/v1",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "Notion-Version": "2021-05-13",
+      },
+    });
   },
   name: "Notion",
   search: async (q) => {
-    if (!notion) {
+    if (!axiosClient) {
       throw Error("Engine not initialized");
     }
 
-    console.log("searching..");
-    const response = await notion.search({
-      query: q,
-      sort: {
-        direction: "ascending",
-        timestamp: "last_edited_time",
-      },
-    });
+    console.log("query for ", q)
 
-    console.log("notion response is... ", notion);
-    return response.results.map(() => ({
-      modified: new Date().getTime(),
-      snippet: "klsdjfdsf",
-      title: "dsfdsfd",
-      url: `https:dsfdsfds`,
-    }));
-    // return data.matches
-    //   .map((m) => m.metadata.metadata)
-    //   .filter((metadata) => !excludeRegex?.test(metadata.path_display))
-    //   .map((metadata) => ({
-    //     modified: getUnixTime(metadata.server_modified),
-    //     snippet: `${metadata[".tag"].charAt(0).toUpperCase()}${metadata[
-    //       ".tag"
-    //     ].slice(1)} in ${metadata.path_display
-    //       .slice(1)
-    //       .replace(/\/[^/]+$/, "")}`,
-    //     title: metadata.name,
-    //     url: `https://www.dropbox.com/home${metadata.path_display}`,
-    //   }));
+    const response = (
+      await axiosClient.post("/search",{}, {
+        data: {
+          query: q,
+          sort: {
+            direction: "ascending",
+            timestamp: "last_edited_time",
+          },
+          filter: {
+            object: 'page'
+          }
+        },
+      })
+    ).data;
 
-    // return {
-    //   modified: "test",
-    // };
+    console.log("notion response is... ", response);
+    const values = response.results.map((result: any) => {
+      const type: 'database' | 'page' = result.object;
+      const title  = result?.properties?.Name?.title[0]?.plain_text;
+      if (result.object === 'page' && title) {
+        console.log("title is", title)
+        return {
+          modified: getUnixTime(result.last_edited_time),
+          snippet: result.object,
+          title: title,
+          url:
+            type === "page"
+              ? `notion://notion.so/${notionWorkspace}/${formatTitle(
+                  title
+                )}-${formatId(result.id)}`
+              : "",
+        };
+      }
+    }).filter((o: any) => (o !== undefined));
+    return values
   },
 };
+
+const formatTitle = (title: string) => (title.replace(/\W+/g, '-'))
+const formatId = (id: string) => (id.replace(/-/g, ""))
 
 export default engine;

--- a/src/engines/notion.ts
+++ b/src/engines/notion.ts
@@ -1,10 +1,20 @@
-
 import axios, { AxiosInstance } from "axios";
 import { getUnixTime } from "../util";
 
 let axiosClient: AxiosInstance | undefined;
 let notionWorkspace: string;
-
+// ,{}, {
+//         data: {
+//           query: q,
+//           sort: {
+//             direction: "ascending",
+//             timestamp: "last_edited_time",
+//           },
+//           filter: {
+//             object: 'page'
+//           }
+//         },
+//       })
 const engine: Engine = {
   id: "notion",
   init: ({ token, workspace }: { token: string; workspace: string }) => {
@@ -25,47 +35,59 @@ const engine: Engine = {
       throw Error("Engine not initialized");
     }
 
-    console.log("query for ", q)
+    console.log("query for ", q);
 
+    // const config = {
+    //   data: {
+    //     query: q,
+    //     sort: {
+    //       direction: "ascending",
+    //       timestamp: "last_edited_time",
+    //     },
+    //     filter: {
+    //       object: "page",
+    //     },
+    //   },
+    // };
     const response = (
-      await axiosClient.post("/search",{}, {
-        data: {
-          query: q,
-          sort: {
-            direction: "ascending",
-            timestamp: "last_edited_time",
-          },
-          filter: {
-            object: 'page'
-          }
+      await axiosClient.post("/search", {
+        query: q,
+        sort: {
+          direction: "ascending",
+          timestamp: "last_edited_time",
         },
+        // filter: {
+        //   object: "page",
+        // },
       })
     ).data;
 
     console.log("notion response is... ", response);
-    const values = response.results.map((result: any) => {
-      const type: 'database' | 'page' = result.object;
-      const title  = result?.properties?.Name?.title[0]?.plain_text;
-      if (result.object === 'page' && title) {
-        console.log("title is", title)
-        return {
-          modified: getUnixTime(result.last_edited_time),
-          snippet: result.object,
-          title: title,
-          url:
-            type === "page"
-              ? `notion://notion.so/${notionWorkspace}/${formatTitle(
-                  title
-                )}-${formatId(result.id)}`
-              : "",
-        };
-      }
-    }).filter((o: any) => (o !== undefined));
-    return values
+    const values = response.results
+      .map((result: any) => {
+        const type: "database" | "page" = result.object;
+        const title = result?.properties?.Name?.title[0]?.plain_text;
+        if (result.object === "page" && title) {
+          console.log("title is", title);
+          return {
+            modified: getUnixTime(result.last_edited_time),
+            snippet: result.object,
+            title: title,
+            url:
+              type === "page"
+                ? `notion://notion.so/${notionWorkspace}/${formatTitle(
+                    title
+                  )}-${formatId(result.id)}`
+                : "",
+          };
+        }
+      })
+      .filter((o: any) => o !== undefined);
+    return values;
   },
 };
 
-const formatTitle = (title: string) => (title.replace(/\W+/g, '-'))
-const formatId = (id: string) => (id.replace(/-/g, ""))
+const formatTitle = (title: string) => title.replace(/\W+/g, "-");
+const formatId = (id: string) => id.replace(/-/g, "");
 
 export default engine;

--- a/src/engines/notion.ts
+++ b/src/engines/notion.ts
@@ -1,0 +1,52 @@
+// import { Client } from "@notionhq/client";
+const { Client } = require("@notionhq/client");
+let notion: typeof Client;
+
+const engine: Engine = {
+  id: "notion",
+  init: ({ token }: { token: string }) => {
+    notion = new Client({ auth: token });
+  },
+  name: "Notion",
+  search: async (q) => {
+    if (!notion) {
+      throw Error("Engine not initialized");
+    }
+
+    console.log("searching..");
+    const response = await notion.search({
+      query: q,
+      sort: {
+        direction: "ascending",
+        timestamp: "last_edited_time",
+      },
+    });
+
+    console.log("notion response is... ", notion);
+    return response.results.map(() => ({
+      modified: new Date().getTime(),
+      snippet: "klsdjfdsf",
+      title: "dsfdsfd",
+      url: `https:dsfdsfds`,
+    }));
+    // return data.matches
+    //   .map((m) => m.metadata.metadata)
+    //   .filter((metadata) => !excludeRegex?.test(metadata.path_display))
+    //   .map((metadata) => ({
+    //     modified: getUnixTime(metadata.server_modified),
+    //     snippet: `${metadata[".tag"].charAt(0).toUpperCase()}${metadata[
+    //       ".tag"
+    //     ].slice(1)} in ${metadata.path_display
+    //       .slice(1)
+    //       .replace(/\/[^/]+$/, "")}`,
+    //     title: metadata.name,
+    //     url: `https://www.dropbox.com/home${metadata.path_display}`,
+    //   }));
+
+    // return {
+    //   modified: "test",
+    // };
+  },
+};
+
+export default engine;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36269621/118356351-2adf2400-b575-11eb-89d7-44368f31efa4.png)

* Simple Notion page search.
* Uses beta search API to find pages and database titles: https://developers.notion.com/reference/post-search.

Caveats:
* Notion API sometimes returns duplicate results when query matches several properties (such as url + title).
* Only included page results because not clear how to create urls from the database results, and users are more likely to search for pages within the database anyway.
* Did not include content preview, which could be fetched with the [block children api](https://developers.notion.com/reference/get-block-children). Page contents may not contain the search query since search API is searches through page titles and properties.