### PR TITLE
Prevent docker build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ _ts:
 	echo 'Installing NPM dependencies...'
 	npm ci
 	echo 'Compiling TypeScript...'
-	node_modules/.bin/tsc
+	NODE_OPTIONS=--max_old_space_size=4096 node_modules/.bin/tsc


### PR DESCRIPTION
Fixes: #16 

In some environments, `docker build` fails because of a memory issue.
This PR prevents this by explicitly setting --max-old-space-size to 4096MB.

https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes