### PR TITLE
Feature/various fixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,8 @@ engines:
     token: Ex4mp1eEx4mp1eEx4mp1eEx4
     # Atlassian user who owns the API token
     user: admin@example.com
+    # optional list of document types to be searched. defaults to [page]
+    documentTypes: [page, blogpost, comment]
 
   # Dropbox files and folders
   dropbox:
@@ -123,7 +125,9 @@ engines:
 
   # Hound-indexed code: https://github.com/hound-search/hound
   hound:
-    # GitHub organization
+    # base url of code hoster. defaults to https://github.com
+    codeHost: https://github.com
+    # optional: GitHub organization
     organization: example
     # Hound server URL origin
     origin: https://hound.example.com

--- a/src/engines/confluence.ts
+++ b/src/engines/confluence.ts
@@ -11,13 +11,18 @@ const normalize = (wikiMarkup: string) =>
     .replace(/@@@(end)?hl@@@/g, "")
     .replace(/\s+/g, " ");
 
+type DocumentType = "blogpost" | "page" | "comment" | "attachment";
+
+let documentTypes: DocumentType[];
+
 const engine: Engine = {
   id: "confluence",
-  init: (options: { origin: string; token: string; user: string }) => {
+  init: (options: { origin: string; token: string; user: string, documentTypes: DocumentType[]|undefined}) => {
     client = axios.create({
       auth: { password: options.token, username: options.user },
       baseURL: `${options.origin}/wiki/rest/api`,
     });
+    documentTypes = options.documentTypes ? options.documentTypes : ["page"];
   },
   name: "Confluence",
   search: async q => {
@@ -31,32 +36,36 @@ const engine: Engine = {
       results: {
         content?: {
           status: "current" | "draft" | "historical" | "trashed";
-          type: "blogpost" | "page";
+          type: DocumentType;
         };
         excerpt: string;
         /** e.g. "2020-06-30T19:04:37.644Z" */
         lastModified: string;
         title: string;
+        resultGlobalContainer: {
+          title: string;
+        };
         url: string;
       }[];
     } = (
       await client.get("/search", {
         params: {
-          cql: `(type = page) AND (text ~ "${escapeQuotes(
+          cql: `(type in (${documentTypes.join(',')})) AND (text ~ "${escapeQuotes(
             q,
           )}") OR (title ~ "${escapeQuotes(q)}")`,
           limit: 1000,
         },
       })
     ).data;
+
     return data.results
       .filter(
-        r => r.content?.status === "current" && r.content?.type === "page",
+        r => r.content?.status === "current",
       )
       .map(r => ({
         modified: getUnixTime(r.lastModified),
         snippet: normalize(r.excerpt),
-        title: normalize(r.title),
+        title: `${r.resultGlobalContainer ? '[' + r.resultGlobalContainer.title + '] ' : ''}${normalize(r.title)}`,
         url: `${data._links.base}${r.url}`,
       }));
   },

--- a/src/engines/hound.ts
+++ b/src/engines/hound.ts
@@ -17,7 +17,7 @@ const engine: Engine = {
   }: {
     name: string | undefined;
     codeHost: string | undefined;
-    organization: string;
+    organization: string | undefined;
     origin: string;
   }) => {
     client = axios.create({ baseURL: `${origin}/api/v1` });

--- a/src/engines/hound.ts
+++ b/src/engines/hound.ts
@@ -3,22 +3,31 @@ import * as he from "he";
 
 let client: AxiosInstance | undefined;
 let org: string | undefined;
+let host: string;
+
+let displayName: string;
 
 const engine: Engine = {
   id: "hound",
   init: ({
+    name,
+    codeHost,
     organization,
     origin,
   }: {
+    name: string | undefined;
+    codeHost: string | undefined;
     organization: string;
     origin: string;
   }) => {
     client = axios.create({ baseURL: `${origin}/api/v1` });
     org = organization;
+    displayName = name ? name : "hound";
+    host = codeHost ? codeHost : "https://github.com"
   },
-  name: "Hound",
+  name: () => displayName,
   search: async q => {
-    if (!(client && org)) {
+    if (!(client && host)) {
       throw Error("Engine not initialized");
     }
 
@@ -53,7 +62,7 @@ const engine: Engine = {
                 ? "(Line too long to display)"
                 : `<code>${he.encode(Line)}</code>`,
             title: `${repo}/${Filename}#L${LineNumber}`,
-            url: `https://github.com/${org}/${repo}/blob/master/${Filename}#L${LineNumber}`,
+            url: `${host}/${org}/${repo}/blob/master/${Filename}#L${LineNumber}`,
           })),
         ),
       )

--- a/src/engines/jira.ts
+++ b/src/engines/jira.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 
-import { escapeQuotes, getUnixTime } from "../util";
+import { escapeQuotes, getUnixTime, trimLines } from "../util";
 
 let client: AxiosInstance | undefined;
 let origin: string | undefined;
@@ -46,7 +46,7 @@ const engine: Engine = {
     ).data;
     return data.issues.map(issue => ({
       modified: getUnixTime(issue.fields.updated),
-      snippet: issue.renderedFields.description,
+      snippet: trimLines(issue.renderedFields.description, q),
       title: `${issue.key}: ${issue.fields.summary}`,
       url: `${origin}/browse/${issue.key}`,
     }));

--- a/src/ui/definitions.d.ts
+++ b/src/ui/definitions.d.ts
@@ -5,7 +5,7 @@ interface Engine {
   id: string;
   init: (options: object) => void | Promise<void>;
   isSnippetLarge?: boolean;
-  name: string;
+  name: string | (() => string);
   search: (q: string) => Promise<Result[]>;
 }
 


### PR DESCRIPTION
Hey,

here is another PR with some smaller changes:
- Confluence engine: the searchable document types are now configurable
- Confluence engine: the result title is now prefixed with the space of the page in [] (if available)
![confluence-space](https://user-images.githubusercontent.com/10358603/150942069-88a9700c-a5a9-4371-8b31-3af06a776f5a.png)
- Jira engine: `trimLines()` is applied to the result content
- Hound engine: the codeHoster must be configurable for result links to work if they are hosted on something else then github.
- Hound engine: I made the displayed name of the hound engine configurable, since the user must not know what hound is. The name can be changed to e.g. `Code` like in the screenshot in the readme.
![hound](https://user-images.githubusercontent.com/10358603/150942871-a7ea68ee-15cc-43d8-9223-7ef3e1e212b0.png)


