### PR TITLE
Support basic auth for Jenkins engine

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -132,6 +132,10 @@ engines:
   jenkins:
     # Jenkins server URL origin
     origin: https://jenkins.example.com
+    # Jenkins API token (optional, requires user)
+    token: 0123456789abcdefg0123456789abcdefg
+    # Jenkins user who owns the API token (optional, requires token)
+    user: username
 
   # Jira issue titles and descriptions
   jira:

--- a/src/engines/jenkins.ts
+++ b/src/engines/jenkins.ts
@@ -19,16 +19,11 @@ const engine: Engine = {
     token?: string;
     user?: string;
   }) => {
-    let config: AxiosRequestConfig = {
-      baseURL: origin,
-    }
+    const config: AxiosRequestConfig = { baseURL: origin };
     // Include basic auth headers if token and user are set
     // https://www.jenkins.io/doc/book/system-administration/authenticating-scripted-clients/
     if (token && user) {
-      config.auth = {
-        username: user,
-        password: token,
-      }
+      config.auth = { password: token, username: user };
     }
     const client = axios.create(config);
 

--- a/src/engines/jenkins.ts
+++ b/src/engines/jenkins.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 
 import { fuzzyIncludes, rateLimit } from "../util";
 
@@ -10,8 +10,27 @@ let getJobs: (() => Promise<Set<Job>>) | undefined;
 
 const engine: Engine = {
   id: "jenkins",
-  init: ({ origin }: { origin: string }) => {
-    const client = axios.create({ baseURL: origin });
+  init: ({
+    origin,
+    token,
+    user,
+  }: {
+    origin: string;
+    token?: string;
+    user?: string;
+  }) => {
+    let config: AxiosRequestConfig = {
+      baseURL: origin,
+    }
+    // Include basic auth headers if token and user are set
+    // https://www.jenkins.io/doc/book/system-administration/authenticating-scripted-clients/
+    if (token && user) {
+      config.auth = {
+        username: user,
+        password: token,
+      }
+    }
+    const client = axios.create(config);
 
     getJobs = rateLimit(async () => {
       // https://stackoverflow.com/a/25685928


### PR DESCRIPTION
Add the `token` and `user` fields to the Jenkins engine, which enable basic authentication via username and token.

See https://www.jenkins.io/doc/book/system-administration/authenticating-scripted-clients/

Closes #9 

Before:
```console
$ make
Installing NPM dependencies...

added 205 packages, and audited 206 packages in 4s

12 vulnerabilities (2 low, 2 moderate, 8 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
Compiling TypeScript...
Compiling Sass...
Serving Metasearch at http://localhost:3000
Request failed with status code 403
403 GET /api/json?tree=jobs[description,name,url]:
{"date":"Mon, 07 Feb 2022 20:44:33 GMT","content-type":"text/html;charset=utf-8", . . .}
"<html><head><meta http-equiv='refresh' content='1;url=/securityRealm/commenceLogin?from=%2Fapi%2Fjson%3Ftree%3Djobs%5Bdescription%2Cname%2Curl%5D'/><script>window.location.replace('/securityRealm/commenceLogin?from=%2Fapi%2Fjson%3Ftree%3Djobs%5Bdescription%2Cname%2Curl%5D');</script></head><body style='background-color:white; color:white;'>\n\n\nAuthentication required\n<!--\n-->\n\n</body></html>                                                                                                                                                                                                                                                                                                            "
make: *** [Makefile:17: all] Error 1
```

After:
![image](https://user-images.githubusercontent.com/16737117/152868975-b366c613-56d0-464d-ab14-992c44ec04cb.png)