### PR TITLE
Align format of Page with Notion API response

### DIFF
--- a/src/engines/notion.ts
+++ b/src/engines/notion.ts
@@ -41,7 +41,7 @@ const engine: Engine = {
     });
   },
   name: "Notion",
-  search: async (q) => {
+  search: async q => {
     if (!axiosClient) {
       throw Error("Engine not initialized");
     }
@@ -68,7 +68,7 @@ const engine: Engine = {
             modified: getUnixTime(result.last_edited_time),
             title: title.plain_text,
             url: `notion://notion.so/${notionWorkspace}/${formatTitle(
-              title.plain_text
+              title.plain_text,
             )}-${formatId(result.id)}`,
           };
         }

--- a/src/engines/notion.ts
+++ b/src/engines/notion.ts
@@ -19,7 +19,10 @@ interface Page {
       type: "title";
       title: RichText[];
     };
-    title?: RichText[];
+    title?: {
+      type: "title";
+      title: RichText[];
+    };
   } & { [propertyName: string]: string };
 }
 
@@ -38,7 +41,7 @@ const engine: Engine = {
     });
   },
   name: "Notion",
-  search: async q => {
+  search: async (q) => {
     if (!axiosClient) {
       throw Error("Engine not initialized");
     }
@@ -59,13 +62,13 @@ const engine: Engine = {
       .map((result: Page) => {
         const title = result.properties.Name
           ? result.properties.Name.title[0]
-          : result.properties.title && result.properties.title[0];
+          : result.properties.title && result.properties.title.title[0];
         if (title) {
           return {
             modified: getUnixTime(result.last_edited_time),
             title: title.plain_text,
             url: `notion://notion.so/${notionWorkspace}/${formatTitle(
-              title.plain_text,
+              title.plain_text
             )}-${formatId(result.id)}`,
           };
         }

--- a/src/engines/notion.ts
+++ b/src/engines/notion.ts
@@ -60,9 +60,8 @@ const engine: Engine = {
       })
     ).data.results
       .map((result: Page) => {
-        const title = result.properties.Name
-          ? result.properties.Name.title[0]
-          : result.properties.title && result.properties.title.title[0];
+        const title =
+          result.properties.Name?.title[0] ?? result.properties.title?.title[0];
         if (title) {
           return {
             modified: getUnixTime(result.last_edited_time),


### PR DESCRIPTION
As described and suggested in the issue #26, I made two changes to [notion.ts](https://github.com/duolingo/metasearch/blob/1413333a99c414eed1eadd8f2a27a582caeb0af4/src/engines/notion.ts).

First, I modified the Page interface such that it resembles the Notion API response for the title property.

(Screenshot of changes)
![image](https://user-images.githubusercontent.com/21250471/156331870-8bd569bf-a9c1-4b31-a464-864e261d8314.png)

(Format of Notion API response)
```typescript
{
  object: 'page',
  id: '452e4692-996d-4db0-a692-ee3446ffcd8d',
  created_time: '2022-03-02T00:49:00.000Z',
  last_edited_time: '2022-03-02T00:49:00.000Z',
  created_by: { object: 'user', id: '846fba0f-3f02-49ec-89f7-245a2b2e87c2' },
  last_edited_by: { object: 'user', id: '846fba0f-3f02-49ec-89f7-245a2b2e87c2' },
  cover: null,
  icon: null,
  parent: { type: 'page_id', page_id: 'ba228e9f-0248-42e5-8f80-0c20e29332dc' },
  archived: false,
  properties: { title: { id: 'title', type: 'title', title: [Array] } },
  url: 'https://www.notion.so/Test-452e4692996d4db0a692ee3446ffcd8d'
}
```

Second, I modified the missing accessor for the title property.

(Screenshot of changes)
![image](https://user-images.githubusercontent.com/21250471/156332994-4c24b924-4d05-498e-9227-fbe754b17173.png)

Without these changes, the search engine returns 0 results because it always mistakes titles as `undefined` (see issue #26 for details).

The following screenshot is proof that I have tested the changes on my own Notion workspace.

![image](https://user-images.githubusercontent.com/21250471/156333697-4f50613f-d83d-4cd3-9df5-0c1cad8bb608.png)
