### PR TITLE
Check for Podman in addition to Docker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ ${JSON.stringify(data)}`);
 
     // Locate user-provided config file
     const dockerizedConfig = `${DOCKER_MOUNT}/${CONFIG_FILENAME}`;
-    const configFile = fs.existsSync("/.dockerenv")
+    const configFile = fs.existsSync("/.dockerenv") || fs.existsSync("/run/.containerenv")
       ? dockerizedConfig
       : CONFIG_FILENAME;
     if (!fs.existsSync(configFile)) {


### PR DESCRIPTION
Support running the `duolingo/metasearch` image with Podman.

`/run/.containerenv` is Podman's equivalent to `.dockerenv`. See: https://docs.podman.io/en/latest/markdown/podman-run.1.html


Before:
```
❯ podman run -p 3000:3000 -v ~/search:/data docker.io/duolingo/metasearch
Metasearch config file 'config.yaml' not found
```

After:
```
❯ podman run -p 3000:3000 -v ~/search:/data metasearch-dev               
Serving Metasearch at http://localhost:3000
```