### PR TITLE
Fix GitHub engine for personal users

### DIFF
--- a/src/engines/github.ts
+++ b/src/engines/github.ts
@@ -40,7 +40,7 @@ const engine: Engine = {
           data,
         }: {
           data?: {
-            organization: {
+            repositoryOwner: {
               repositories: {
                 edges: { node: Repo }[];
                 pageInfo: { endCursor: string; hasNextPage: boolean };
@@ -52,7 +52,7 @@ const engine: Engine = {
             "/graphql",
             JSON.stringify({
               query: `query {
-      organization(login: "${organization}") { repositories(first: 100${
+      repositoryOwner(login: "${organization}") { repositories(first: 100${
                 cursor ? `, after: "${cursor}"` : ""
               }) {
           edges { node { description isArchived isFork name } }
@@ -66,7 +66,7 @@ const engine: Engine = {
           break;
         }
 
-        const { edges, pageInfo } = data.organization.repositories;
+        const { edges, pageInfo } = data.repositoryOwner.repositories;
         edges.map(e => e.node).forEach(r => repos.add(r));
 
         if (pageInfo.hasNextPage) {


### PR DESCRIPTION
Use the [RepositoryOwner](https://docs.github.com/en/graphql/reference/interfaces#repositoryowner)
interface to query GitHub rather than the Organization interface. This
allows GraphQL queries to work on both organizations and user spaces.

**Before**

Personal:
```console
❯ podman run -p 3000:3000 -v ~/search:/data metasearch-master
Serving Metasearch at http://localhost:3000
Cannot read property 'repositories' of null
```

Organization:
```console
TODO
```

**After**

Personal:
```console
❯ podman run -p 3000:3000 -v ~/search:/data metasearch-dev   
Serving Metasearch at http://localhost:3000
```

Organization:
```console
TODO
```
