### PR TITLE
Support Google Drive shared folder search

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,14 @@ engines:
     #
     # https://console.developers.google.com/apis/credentials
     # https://github.com/googleapis/google-api-nodejs-client/tree/62f8193#oauth2-client
+    # https://developers.google.com/drive/api/reference/rest/v3/files/list
+    #
+    # a corpora of `allDrives` can be used to search all drives including shared ones,
+    # if you use this, you will also need to update the values of
+    # `includeItemsFromAllDrives` and `supportsAllDrives` to true
+    corpora: "domain"
+    includeItemsFromAllDrives: false
+    supportsAllDrives: false
     #
     # Note that if you run Metasearch using Docker, you need to make the host's
     # credentials file accessible from inside the container. One way to do so is

--- a/config.yaml
+++ b/config.yaml
@@ -58,14 +58,6 @@ engines:
     #
     # https://console.developers.google.com/apis/credentials
     # https://github.com/googleapis/google-api-nodejs-client/tree/62f8193#oauth2-client
-    # https://developers.google.com/drive/api/reference/rest/v3/files/list
-    #
-    # a corpora of `allDrives` can be used to search all drives including shared ones,
-    # if you use this, you will also need to update the values of
-    # `includeItemsFromAllDrives` and `supportsAllDrives` to true
-    corpora: "domain"
-    includeItemsFromAllDrives: false
-    supportsAllDrives: false
     #
     # Note that if you run Metasearch using Docker, you need to make the host's
     # credentials file accessible from inside the container. One way to do so is

--- a/src/engines/drive.ts
+++ b/src/engines/drive.ts
@@ -32,7 +32,7 @@ const getMimeInfo = (
 
 const engine: Engine = {
   id: "drive",
-  init: ({ credentials, token}: { credentials: string; token: string}) => {
+  init: ({ credentials, token }: { credentials: string; token: string }) => {
     // https://github.com/googleapis/google-api-nodejs-client/tree/62f8193#oauth2-client
     const {
       web: { client_id, client_secret },

--- a/src/engines/drive.ts
+++ b/src/engines/drive.ts
@@ -6,9 +6,6 @@ import { OAuth2Client } from "google-auth-library";
 import { getUnixTime } from "../util";
 
 let auth: OAuth2Client | undefined;
-let corporaSetting: string;
-let includeItemsFromAllDrivesSetting: boolean;
-let supportsAllDrivesSetting: boolean;
 
 // https://developers.google.com/drive/api/v3/mime-types
 const getMimeInfo = (
@@ -35,16 +32,13 @@ const getMimeInfo = (
 
 const engine: Engine = {
   id: "drive",
-  init: ({ credentials, token, corpora = "domain", includeItemsFromAllDrives = false, supportsAllDrives = false }: { credentials: string; token: string, corpora: string, includeItemsFromAllDrives: boolean, supportsAllDrives: boolean }) => {
+  init: ({ credentials, token}: { credentials: string; token: string}) => {
     // https://github.com/googleapis/google-api-nodejs-client/tree/62f8193#oauth2-client
     const {
       web: { client_id, client_secret },
     } = JSON.parse(fs.readFileSync(credentials, "utf8"));
     auth = new google.auth.OAuth2(client_id, client_secret);
     auth.setCredentials({ refresh_token: token });
-    corporaSetting = corpora;
-    includeItemsFromAllDrivesSetting = includeItemsFromAllDrives;
-    supportsAllDrivesSetting = supportsAllDrives;
   },
   name: "Google Drive",
   search: async q => {
@@ -56,12 +50,12 @@ const engine: Engine = {
     const data = await drive.files.list({
       // Searches "Visible to anyone in..."
       // https://developers.google.com/drive/api/v3/search-files#search_the_corpora
-      corpora: corporaSetting,
+      corpora: "allDrives",
       fields: "files(description,id,kind,mimeType,modifiedTime,name,owners)",
       q: `fullText contains '${q.replace(/'/, "\\'")}'`,
       spaces: "drive",
-      includeItemsFromAllDrives: includeItemsFromAllDrivesSetting,
-      supportsAllDrives: supportsAllDrivesSetting,
+      includeItemsFromAllDrives: true,
+      supportsAllDrives: true,
     });
     return (
       data.data.files?.map(f => {


### PR DESCRIPTION
<!-- Please include at least one screenshot of your change. Thanks! -->
My organization uses shared drives in google drive and we were not able to query the files without enabling all drives. The results are a bit slower but they allowed to us to be able to see all files from shared drives.

See the difference between google drive files returned: 

before: 
![image](https://github.com/duolingo/metasearch/assets/153962276/e8f44dfe-5808-4d7a-aebd-32cf4861f3f3)

after:
![image](https://github.com/duolingo/metasearch/assets/153962276/aee75ce4-6725-4928-8231-78f338d8d217)

I've made the code compatible with existing configurations and set defaults. I'm not a typescript developer, so please let me know if something is not standard. 

Thanks,
Michael
Email: michael.peng@hootsuite.com


